### PR TITLE
[Docs] Fix typo in upload plugin

### DIFF
--- a/docs/3.0.0-beta.x/plugins/upload.md
+++ b/docs/3.0.0-beta.x/plugins/upload.md
@@ -213,7 +213,7 @@ And for your files, they have to be prefixed by `files`.
 Example here with cover attribute `files.cover`.
 
 ::: tip
-If you want to upload files for a component, you will have to specify the inidex of the item you wan to add the file.
+If you want to upload files for a component, you will have to specify the index of the item you want to add the file.
 Example `files.my_component_name[the_index].attribute_name`
 :::
 


### PR DESCRIPTION
Hi,

#### Description of what you did:

I've corrected some typo mistakes in the upload plugin documentation.

#### My PR is a:

- [ ] 💥 Breaking change
- [ ] 🐛 Bug fix
- [x] 💅 Enhancement
- [ ] 🚀 New feature

#### Main update on the:

- [ ] Admin
- [x] Documentation
- [ ] Framework
- [ ] Plugin

#### Manual testing done on the following databases:

- [x] Not applicable
- [ ] MongoDB
- [ ] MySQL
- [ ] Postgres
- [ ] SQLite

You can merge it, it's not a WIP ;)
